### PR TITLE
Fixed missing newLanguageDetector export

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,6 @@
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { beforeEach, describe, expect, it } from 'bun:test'
 import Elysia from 'elysia'
-import { i18next } from './index.ts'
+import { i18next, newLanguageDetector, LanguageDetector } from './index.ts'
 import { createInstance, InitOptions, i18n } from 'i18next'
 
 export const req = (path: string, requestInit?: RequestInit) =>
@@ -109,5 +109,22 @@ describe('i18next', () => {
       .get('/', ({ t }) => t('greeting'))
     const response = await app.handle(req('/'))
     expect(await response.text()).toEqual('Bonjour!')
+  })
+
+  it('changes language using a custom LanguageDetector created with newLanguageDetector()', async () => {
+    const detector: LanguageDetector = newLanguageDetector({
+      searchParamName: 'x-lang',
+      storeParamName: 'x-lang',
+      headerName: 'x-lang',
+      cookieName: 'x-lang',
+      pathParamName: 'x-lang',
+    })
+
+    const app = new Elysia()
+      .use(i18next({ instance, detectLanguage: detector }))
+      .get('/', ({ t }) => t('greeting'))
+
+    const response = await app.handle(req('/?x-lang=en'))
+    expect(await response.text()).toEqual('Hello!')
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ export type LanguageDetector<
   T extends Context<RouteSchema> = Context<RouteSchema>,
 > = (ctx: T) => null | string | Promise<string | null>
 
-function newLanguageDetector(opts: LanguageDetectorOptions): LanguageDetector {
+export function newLanguageDetector(opts: LanguageDetectorOptions): LanguageDetector {
   return ({ set, request, params, store }) => {
     const url = new URL(request.url)
 


### PR DESCRIPTION
This PR addresses the reported [issue](https://github.com/eelkevdbos/elysia-i18next/issues/2) regarding the missing export of `newLanguageDetector`. The issue was identified in the` examples/detect.ts` file, where users were instructed to import newLanguageDetector. However, it was found that the export was missing in the `src/index.ts` file.

**Changes:**
- Added the missing export for `newLanguageDetector` in `src/index.ts`.
- Included a new test in `src/index.test.ts` to validate the usage of `newLanguageDetector()`.

**Additional Changes:**
- Removed an unused import (`afterEach`) in `src/index.test.ts`.