### PR TITLE
Fixed failure to apply a default language after a request with specified language

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,11 @@ A language detection function based on the current request context. By default, 
 Default: `null`
 
 An existing i18next instance. If not provided, the global (module level) i18next instance will be used. The instance will be initialized if it not already was initialized.
+
+### useLngAsDefault
+
+`boolean`
+
+Default: `true`
+
+If `true`, the language will be set to `initOptions.lng` if no language was detected and `initOptions.lng` is defined. Otherwise, the previous language will be used.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -129,4 +129,21 @@ describe('i18next', () => {
     response = await app.handle(req('/'))
     expect(await response.text()).toEqual('Hello!')
   })
+
+  it('should not fall back to initOptions.lng after a request with specified language if useLngAsDefault is false', async () => {
+	  instance = createInstance({
+	  	...initOptions,
+	  	lng: 'en',
+	  })
+
+	  const app = new Elysia()
+	    .use(i18next({ instance, useLngAsDefault: false }))
+	    .get('/', ({ t }) => t('greeting'))
+
+	  let response = await app.handle(req('/?lang=fr'))
+	  expect(await response.text()).toEqual('Bonjour!')
+
+	  response = await app.handle(req('/'))
+	  expect(await response.text()).toEqual('Bonjour!')
+  })
 })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -110,4 +110,23 @@ describe('i18next', () => {
     const response = await app.handle(req('/'))
     expect(await response.text()).toEqual('Bonjour!')
   })
+
+  it('should fall back to initOptions.lng after a request with specified language', async () => {
+    instance = createInstance({
+		  ...initOptions,
+		  lng: 'en',
+	  })
+	
+	  const app = new Elysia()
+      .use(i18next({ instance }))
+      .get('/', ({ t }) => t('greeting'))
+
+	  // language is specified in the first request
+    let response = await app.handle(req('/?lang=fr'))
+    expect(await response.text()).toEqual('Bonjour!')
+
+	  // language is not specified in the next request
+    response = await app.handle(req('/'))
+    expect(await response.text()).toEqual('Hello!')
+  })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export type I18NextPluginOptions = {
   initOptions: InitOptions
   detectLanguage: LanguageDetector
   instance: null | i18n
+  useLngAsDefault: boolean
 }
 
 export type LanguageDetectorOptions = {
@@ -63,6 +64,7 @@ const defaultOptions: I18NextPluginOptions = {
     cookieName: 'lang',
     pathParamName: 'lang',
   }),
+  useLngAsDefault: true,
 }
 
 export const i18next = (userOptions: Partial<I18NextPluginOptions>) => {
@@ -81,9 +83,16 @@ export const i18next = (userOptions: Partial<I18NextPluginOptions>) => {
       return { i18n: _instance, t: _instance.t }
     })
     .onBeforeHandle(async ctx => {
-      const lng = await options.detectLanguage(ctx)
-      if (lng) {
-        await _instance.changeLanguage(lng)
+      const detectedLanguage = await options.detectLanguage(ctx)
+      if (detectedLanguage) {
+        await _instance.changeLanguage(detectedLanguage)
+        return
       }
+
+      const { options: { lng }, language: currentLanguage } = _instance
+
+      if (options.useLngAsDefault && lng && currentLanguage !== lng) {
+        await _instance.changeLanguage(lng)
+	    }
     })
 }


### PR DESCRIPTION
## Description:

This pull request addresses the [issue](https://github.com/eelkevdbos/elysia-i18next/issues/4) where the application, after a request with a specified language, fails to revert to a default language when the subsequent request does not specify a language. The current behavior retains the previous language instead of falling back to a default language, eg. the one set in `initOptions.lng`.

## Changes Made:

1. **Code Modification:**
   - Updated the logic in `onBeforeHandle`; If a language is not detected and the new `useLngAsDefault` option is true, it falls back to the default language specified in `initOptions.lng`.
   
        ```ts
        // src/index.ts
        .onBeforeHandle(async ctx => {
            const detectedLanguage = await options.detectLanguage(ctx)
            if (detectedLanguage) {
                await _instance.changeLanguage(detectedLanguage)
                return
            }

            const { options: { lng }, language: currentLanguage } = _instance

            if (options.useLngAsDefault && lng && currentLanguage !== lng) {
                await _instance.changeLanguage(lng)
	        }
        })
        ```

2. **New Option:**
   - Introduced a new option `useLngAsDefault` (defaults to `true`) to control whether the application should use the default language when a language is not specified/detected in a request.

        ```ts
        const app = new Elysia()
            .use(i18next({ instance, useLngAsDefault: true }))
            .get('/', ({ t }) => t('greeting'))
        ```

3. **Test Cases:**
   - Added a new test case to validate that the application falls back to the default language after a request with a specified language.
   - Added a test case to verify that opting out from using the default language (`useLngAsDefault: false`) works as intended.

4. **Documentation:**
   - Updated the README to include information about the new option `useLngAsDefault`.

**Thank you for reviewing this pull request!**